### PR TITLE
periodically discover new speakers

### DIFF
--- a/pkg/bll/ticker/ticker.go
+++ b/pkg/bll/ticker/ticker.go
@@ -1,0 +1,26 @@
+package ticker
+
+import (
+	"context"
+	"time"
+)
+
+func Every(ctx context.Context, d time.Duration) <-chan time.Time {
+	c := make(chan time.Time)
+
+	go func() {
+		defer close(c)
+		for {
+			c <- time.Now()
+
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(d):
+			}
+		}
+	}()
+
+	return c
+
+}


### PR DESCRIPTION
The original idea was that one can simply restart devilctl when there is a new speaker since this does not happen often. But this does not work, because existing speakers might get a new IP or just change the port (I guess this happens on a speaker restart). Therefore we scan periodically for new devices (but do not clean up old ones).
